### PR TITLE
feat: add template of individual and digest emails

### DIFF
--- a/platform_plugin_forum_email_notifier/handlers.py
+++ b/platform_plugin_forum_email_notifier/handlers.py
@@ -7,7 +7,7 @@ from openedx_events.learning.signals import (
 )
 
 from platform_plugin_forum_email_notifier.tasks import notify_users
-from platform_plugin_forum_email_notifier.utils import ForumObject
+from platform_plugin_forum_email_notifier.utils import ForumObject, get_base_email_context
 
 
 @receiver(FORUM_THREAD_CREATED)
@@ -28,6 +28,7 @@ def forum_thread_created_handler(
         thread.user.pii.username,
         thread.user.pii.email,
         object_type=ForumObject.THREAD,
+        context=get_base_email_context(),
     )
 
 
@@ -49,6 +50,7 @@ def forum_response_created_handler(
         thread.user.pii.username,
         thread.user.pii.email,
         object_type=ForumObject.RESPONSE,
+        context=get_base_email_context(),
     )
 
 
@@ -70,4 +72,5 @@ def forum_comment_created_handler(
         thread.user.pii.username,
         thread.user.pii.email,
         object_type=ForumObject.COMMENT,
+        context=get_base_email_context(),
     )

--- a/platform_plugin_forum_email_notifier/management/commands/forum_digest.py
+++ b/platform_plugin_forum_email_notifier/management/commands/forum_digest.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 from platform_plugin_forum_email_notifier.models import ForumNotificationDigest, PreferenceOptions
 from platform_plugin_forum_email_notifier.tasks import send_digest
+from platform_plugin_forum_email_notifier.utils import get_base_email_context
 
 log = logging.getLogger(__name__)
 
@@ -73,4 +74,4 @@ class Command(BaseCommand):
                 f"Generating {display_name} digest for user {digest.user.id} in course {digest.course_id}"
             )
 
-            send_digest.delay(digest.id)
+            send_digest.delay(digest.id, context=get_base_email_context())

--- a/platform_plugin_forum_email_notifier/static/html/forum_notifier.html
+++ b/platform_plugin_forum_email_notifier/static/html/forum_notifier.html
@@ -1,15 +1,35 @@
 {% load i18n %}
 
 <div class="email-notifier-instructor-wrapper">
-    {% trans "Forum email notifications preferences" %}
+    <div>
+        <p class="title-list">{% trans "In this section you can set your email notification preferences for the discussion forum. The available options are:" %}</p>
+        <ul class="list-container">
+            <li>{% trans "None: I don't want to receive any email notifications." %}</li>
+            <li>{% trans "All posts: I want to receive email notifications for all posts." %}</li>
+            <li>
+                {% trans "Only posts I'm following: I want to receive email notifications for posts I'm following." %}
+            </li>
+            <li>
+                {% trans "All posts (Daily digest): I want to receive email notifications for all posts in a daily digest." %}
+            </li>
+            <li>
+                {% trans "All posts (Weekly digest): I want to receive email notifications for all posts in a weekly digest." %}
+            </li>
+        </ul>
+    </div>
 
-    <select class="email-notifications-select">
+    <p><b>{% trans "These notifications are only sent to the instructor of the course." %}</b></p>
+    <p>{% trans "The available notifications of the discussion forum are: created post, response to post, comment to post. These notifications are sent to the email address associated with your account. Below you can select the type of notifications you want to receive:" %}</p>
+
+    <select class="dropdown email-notifications-select">
         {% for value, text in options %}
-        {% if value == current_preference  %}
-        <option class="email-notifications-options" value={{value}} selected>{{ text }}</option>
-        {% else %}
-        <option class="email-notifications-options" value={{value}}>{{ text }}</option>
-        {% endif %}
+            {% if value == current_preference %}
+                <option class="email-notifications-options" value="{{value}}" selected>{{ text }}</option>
+            {% else %}
+                <option class="email-notifications-options" value="{{value}}">{{ text }}</option>
+            {% endif %}
         {% endfor %}
     </select>
 </div>
+
+<script type="text/javascript" src="/platform_plugin_forum_email_notifier/static/js/src/forum_notifier.js"></script>

--- a/platform_plugin_forum_email_notifier/static/js/forum_notifier.js
+++ b/platform_plugin_forum_email_notifier/static/js/forum_notifier.js
@@ -1,33 +1,45 @@
 function getCookie(name) {
   let cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-      const cookies = document.cookie.split(';');
-      for (let i = 0; i < cookies.length; i++) {
-          const cookie = cookies[i].trim();
-          // Does this cookie string begin with the name we want?
-          if (cookie.substring(0, name.length + 1) === (name + '=')) {
-              cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-              break;
-          }
+  if (document.cookie && document.cookie !== "") {
+    const cookies = document.cookie.split(";");
+    for (let i = 0; i < cookies.length; i++) {
+      const cookie = cookies[i].trim();
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) === name + "=") {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
       }
+    }
   }
   return cookieValue;
 }
 
-
-$('.email-notifications-select').on('change', function(select) {
-  fetch('instructor/api/forum_email_notification_preference', {
-    method: 'PUT',
+$(".email-notifications-select").on("change", function (select) {
+  fetch("instructor/api/forum_email_notification_preference", {
+    method: "PUT",
     body: JSON.stringify({
-      'preference': parseInt($(this).val())
+      preference: parseInt($(this).val()),
     }),
     headers: {
-      'Content-Type': 'application/json',
-      'X-CSRFToken': getCookie('csrftoken')
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCookie("csrftoken"),
     },
-    }).then(function(response) {
+  })
+    .then(function (response) {
       return response.json();
-    }).then(function(data) {
+    })
+    .then(function (data) {
       console.log(data);
     });
+});
+
+$(function () {
+  const cssUrl = "https://cdn.jsdelivr.net/npm/@edx/paragon@20.45.5/dist/paragon.min.css";
+
+  $("<link>")
+    .attr({
+      href: cssUrl,
+      rel: "stylesheet",
+    })
+    .appendTo("head");
 });

--- a/platform_plugin_forum_email_notifier/tasks.py
+++ b/platform_plugin_forum_email_notifier/tasks.py
@@ -10,9 +10,7 @@ from edx_ace.recipient import Recipient
 from edx_django_utils.monitoring import set_code_owner_attribute
 
 try:
-    from openedx.core.djangoapps.content.course_overviews.api import (
-        get_course_overview_or_none,
-    )
+    from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
     from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
     from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 except ImportError:
@@ -20,21 +18,13 @@ except ImportError:
     LANGUAGE_KEY = object
     get_user_preference = object
 
-
-from platform_plugin_forum_email_notifier.email import (
-    send_digest_email_notification,
-    send_forum_email_notification,
-)
+from platform_plugin_forum_email_notifier.email import send_digest_email_notification, send_forum_email_notification
 from platform_plugin_forum_email_notifier.models import (
     ForumNotificationDigest,
     ForumNotificationPreference,
     PreferenceOptions,
 )
-from platform_plugin_forum_email_notifier.utils import (
-    ForumObject,
-    get_staff_subscribers,
-    get_subscribers,
-)
+from platform_plugin_forum_email_notifier.utils import ForumObject, get_staff_subscribers, get_subscribers
 
 log = logging.getLogger(__name__)
 celery_log = logging.getLogger("edx.celery.task")

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/body.html
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/body.html
@@ -2,32 +2,30 @@
 
 {% load i18n %}
 {% load static %}
+
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
             <h1>
-                {% trans "Forum Digest" as tmsg %}{{ tmsg | force_escape }}
+                {% trans "Summary of Discussion Activity" as tmsg %}{{ tmsg | force_escape }}
             </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Activity in the discussion:{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
 
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Visit discussions{% endblocktrans %}
-            {% endfilter %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_link %}
+            {% for thread in threads %}
+                <p style="color: rgba(0,0,0,.75);">
+                    <a href="{{ thread.url }}discussions/{{ course_id }}/posts/{{ thread.thread_id }}">{{ thread.title }}</a>: {{ thread.body }}...
+                    <br />
+                </p>
+            {% endfor %}
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}.{% endblocktrans %}
-                {% endfilter %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                {% blocktrans %}You are receiving this email because you set your preferences to receive a summary of all discussion activity. To stop receiving this email, please change your settings{% endblocktrans %}
+                <a href="{{ forum_notifier_url }}">{% trans "here" %}</a>.
+                {% endautoescape %}
                 <br />
             </p>
-
         </td>
     </tr>
 </table>

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/body.html
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/body.html
@@ -12,10 +12,22 @@
             </h1>
 
             {% for thread in threads %}
-                <p style="color: rgba(0,0,0,.75);">
-                    <a href="{{ thread.url }}discussions/{{ course_id }}/posts/{{ thread.thread_id }}">{{ thread.title }}</a>: {{ thread.body }}...
-                    <br />
-                </p>
+                {% if thread.object_type == 1 %}
+                    <p style="color: rgba(0,0,0,.75);">
+                        <a href="{{ thread.url }}discussions/{{ course_id }}/posts/{{ thread.thread_id }}">{{ thread.title }} ↗</a>: {{ thread.body }}
+                        <br />
+                    </p>
+                {% elif thread.object_type == 2 %}
+                    <p style="color: rgba(0,0,0,.75);">
+                        <i>{% trans "Response" %}</i>: {{ thread.body }}
+                        <br />
+                    </p>
+                {% else %}
+                    <p style="color: rgba(0,0,0,.75);">
+                        <i>{% trans "Comment" %}</i>: {{ thread.body }}
+                        <br />
+                    </p>
+                {% endif %}
             {% endfor %}
 
             <p style="color: rgba(0,0,0,.75);">

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/body.txt
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/body.txt
@@ -1,6 +1,13 @@
-{% load i18n %}{% autoescape off %}
-{% blocktrans %}We received a request to change the e-mail associated with your {{ platform_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please confirm your new e-mail address by visiting:{% endblocktrans %}
+{% load i18n %}
 
-{{ confirm_link }}
+{% autoescape off %}
+    {% blocktrans %}Summary of Discussion Activity{% endblocktrans %}
 
-{% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ platform_name }} web site.{% endblocktrans %}{% endautoescape %}
+    {% for thread in threads %}
+        {{ thread.title}}: {{ thread.body }}.
+        {% blocktrans %}To view the thread, click the link below: {% endblocktrans %}{{ thread.url }}discussions/{{ course_id }}/posts/{{ thread.thread_id }}
+
+    {% endfor %}
+
+    {% blocktrans %}You are receiving this email because you set your preferences to receive a summary of all discussion activity. To stop receiving this email, please change your settings in the following link: {{ forum_notifier_url }}{% endblocktrans %}
+{% endautoescape %}

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/body.txt
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/body.txt
@@ -4,9 +4,14 @@
     {% blocktrans %}Summary of Discussion Activity{% endblocktrans %}
 
     {% for thread in threads %}
-        {{ thread.title}}: {{ thread.body }}.
-        {% blocktrans %}To view the thread, click the link below: {% endblocktrans %}{{ thread.url }}discussions/{{ course_id }}/posts/{{ thread.thread_id }}
-
+        {% if object_type == 1 %}
+            {{ thread.title}}: {{ thread.body }}
+            {% blocktrans %}To view the thread, click the link below: {% endblocktrans %}{{ thread.url }}discussions/{{ course_id }}/posts/{{ thread.thread_id }}
+        {% elif object_type == 2 %}
+            {% trans "Comment" %}: {{ thread.body }}
+        {% else %}
+            {% trans "Response" %}: {{ thread.body }}
+        {% endif %}
     {% endfor %}
 
     {% blocktrans %}You are receiving this email because you set your preferences to receive a summary of all discussion activity. To stop receiving this email, please change your settings in the following link: {{ forum_notifier_url }}{% endblocktrans %}

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/subject.txt
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/digestemailnotification/email/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans trimmed %}Forum Digest {{ course_name }} {% endblocktrans %}
+{% blocktrans trimmed %}Summary of discussion activity in {{ course_name }} {% endblocktrans %}
 {% endautoescape %}

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.html
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.html
@@ -20,9 +20,7 @@
                 </p>
 
                 <h3 style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
-                    {{ title }}:
-                    {% endfilter %}
+                    {% autoescape off %}{{ title }}:{% endautoescape %}
                     <br />
                 </h3>
             {% elif object_type == 2 %}
@@ -44,9 +42,7 @@
             {% endif %}
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {{ body }}...
-                {% endfilter %}
+                {% autoescape off %}{{ body }}...{% endautoescape %}
                 <br />
             </p>
 

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.html
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.html
@@ -42,7 +42,7 @@
             {% endif %}
 
             <p style="color: rgba(0,0,0,.75);">
-                {% autoescape off %}{{ body }}...{% endautoescape %}
+                {% autoescape off %}{{ body }}{% endautoescape %}
                 <br />
             </p>
 

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.html
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.html
@@ -7,27 +7,61 @@
     <tr>
         <td>
             <h1>
-                {% trans "Forum Activity" as tmsg %}{{ tmsg | force_escape }}
+                {% trans "Discussion Activity" as tmsg %}{{ tmsg | force_escape }}
             </h1>
+
+            {% if object_type == 1 %}
+                <p style="color: rgba(0,0,0,.75);">
+                    {% autoescape off %}
+                    {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                    {% blocktrans %}User {{ author_username }} created a discussion thread:{% endblocktrans %}
+                    {% endautoescape %}
+                    <br />
+                </p>
+
+                <h3 style="color: rgba(0,0,0,.75);">
+                    {% filter force_escape %}
+                    {{ title }}:
+                    {% endfilter %}
+                    <br />
+                </h3>
+            {% elif object_type == 2 %}
+                <p style="color: rgba(0,0,0,.75);">
+                    {% autoescape off %}
+                    {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                    {% blocktrans %}User {{ author_username }} responded to a comment in a discussion thread that you are following:{% endblocktrans %}
+                    {% endautoescape %}
+                    <br />
+                </p>
+            {% else %}
+                <p style="color: rgba(0,0,0,.75);">
+                    {% autoescape off %}
+                    {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                    {% blocktrans %}User {{ author_username }} commented in a discussion thread that you are following:{% endblocktrans %}
+                    {% endautoescape %}
+                    <br />
+                </p>
+            {% endif %}
+
             <p style="color: rgba(0,0,0,.75);">
                 {% filter force_escape %}
-                {% blocktrans %}Activity in the discussion:{% endblocktrans %}
+                {{ body }}...
                 {% endfilter %}
                 <br />
             </p>
 
             {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Visit discussions{% endblocktrans %}
+                {% blocktrans asvar course_cta_text %}View in discussions{% endblocktrans %}
             {% endfilter %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_link %}
+            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text reset_url=url %}
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}.{% endblocktrans %}
-                {% endfilter %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                {% blocktrans %}You are receiving this email because you are following this thread in the discussions panel of the course. Click the star sign from the thread to stop following.{% endblocktrans %}
+                {% endautoescape %}
                 <br />
             </p>
-
         </td>
     </tr>
 </table>

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.txt
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.txt
@@ -1,6 +1,20 @@
-{% load i18n %}{% autoescape off %}
-{% blocktrans %}We received a request to change the e-mail associated with your {{ platform_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please confirm your new e-mail address by visiting:{% endblocktrans %}
+{% load i18n %}
 
-{{ confirm_link }}
+{% autoescape off %}
+    {% blocktrans %}Discussion Activity{% endblocktrans %}
 
-{% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ platform_name }} web site.{% endblocktrans %}{% endautoescape %}
+    {% if object_type == 1 %}
+        {% blocktrans %}User {{ author_username }} created a discussion thread:{% endblocktrans %}
+        {{ title }}:
+    {% elif object_type == 2 %}
+        {% blocktrans %}User {{ author_username }} responded to a comment in a discussion thread that you are following:{% endblocktrans %}
+    {% else %}
+        {% blocktrans %}User {{ author_username }} commented in a discussion thread that you are following:{% endblocktrans %}
+    {% endif %}
+
+    {{ body }}...
+
+    {% blocktrans %}To view the discussion thread, click the link below: {{ url }}{% endblocktrans %}
+
+    {% blocktrans %}You are receiving this email because you are following this thread in the discussions panel of the course. Click the star sign from the thread to stop following.{% endblocktrans %}
+{% endautoescape %}

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.txt
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/body.txt
@@ -12,7 +12,7 @@
         {% blocktrans %}User {{ author_username }} commented in a discussion thread that you are following:{% endblocktrans %}
     {% endif %}
 
-    {{ body }}...
+    {{ body }}
 
     {% blocktrans %}To view the discussion thread, click the link below: {{ url }}{% endblocktrans %}
 

--- a/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/subject.txt
+++ b/platform_plugin_forum_email_notifier/templates/platform_plugin_forum_email_notifier/edx_ace/forumemailnotification/email/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans trimmed %}Discussion activity in {{ course_name }} {% endblocktrans %}
+{% blocktrans trimmed %}New discussion activity in {{ course_name }} {% endblocktrans %}
 {% endautoescape %}

--- a/platform_plugin_forum_email_notifier/utils.py
+++ b/platform_plugin_forum_email_notifier/utils.py
@@ -2,14 +2,42 @@
 from enum import IntEnum
 
 from bs4 import BeautifulSoup
+from django.contrib.sites.models import Site
 
 try:
+    from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
     from openedx.core.djangoapps.django_comment_common.comment_client import settings, utils
 except ImportError:
     settings = object
     utils = object
+    get_base_template_context = object
 
 from platform_plugin_forum_email_notifier.models import ForumNotificationPreference, PreferenceOptions
+
+
+def get_base_email_context() -> dict:
+    """
+    Return the base email context.
+
+    Returns:
+        dict: The base email context.
+    """
+    site = Site.objects.get_current()
+    return get_base_template_context(site)
+
+
+def truncate_text(text: str, max_length=160, suffix="..."):
+    """
+    Return a truncated version of the text.
+
+    Args:
+        text (str): The text to truncate.
+        max_length (int, optional): The maximum length of the text. Defaults to 160.
+        suffix (str, optional): The suffix to append to the truncated text. Defaults to "...".
+    """
+    if len(text) <= max_length:
+        return text
+    return f"{text[:max_length]}{suffix}"
 
 
 def get_simplified_text(text: str) -> str:
@@ -26,7 +54,7 @@ def get_simplified_text(text: str) -> str:
     """
     soup = BeautifulSoup(text, "html.parser")
     text = soup.get_text()
-    return text if len(text) <= 160 else f"{text[:160]}..."
+    return truncate_text(text)
 
 
 def get_subscribers(thread_id):

--- a/platform_plugin_forum_email_notifier/utils.py
+++ b/platform_plugin_forum_email_notifier/utils.py
@@ -1,6 +1,8 @@
 """Utilities for the platform_plugin_forum_email_notifier plugin."""
 from enum import IntEnum
 
+from bs4 import BeautifulSoup
+
 try:
     from openedx.core.djangoapps.django_comment_common.comment_client import settings, utils
 except ImportError:
@@ -8,6 +10,23 @@ except ImportError:
     utils = object
 
 from platform_plugin_forum_email_notifier.models import ForumNotificationPreference, PreferenceOptions
+
+
+def get_simplified_text(text: str) -> str:
+    """
+    Return the simplified text of a html string.
+
+    If the text is longer than 160 characters, it will be truncated.
+
+    Args:
+        text (str): The html string.
+
+    Returns:
+        str: The simplified text.
+    """
+    soup = BeautifulSoup(text, "html.parser")
+    text = soup.get_text()
+    return text if len(text) <= 160 else f"{text[:160]}..."
 
 
 def get_subscribers(thread_id):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,3 +10,4 @@ edx_ace
 openedx_filters
 web_fragments
 django-rest-framework
+beautifulsoup4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,8 @@ backports-zoneinfo[tzdata]==0.2.1
     # via
     #   celery
     #   kombu
+beautifulsoup4==4.12.2
+    # via -r requirements/base.in
 billiard==4.1.0
     # via celery
 celery==5.3.4
@@ -75,7 +77,7 @@ kombu==5.3.2
     # via celery
 newrelic==9.1.0
     # via edx-django-utils
-openedx-events==8.9.0
+openedx-events==9.0.0
     # via -r requirements/base.in
 openedx-filters==1.6.0
     # via -r requirements/base.in
@@ -83,7 +85,7 @@ pbr==5.11.1
     # via stevedore
 prompt-toolkit==3.0.39
     # via click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via edx-django-utils
 pycparser==2.21
     # via cffi
@@ -103,12 +105,14 @@ requests==2.31.0
     # via sailthru-client
 sailthru-client==2.2.3
     # via edx-ace
-simplejson==3.19.1
+simplejson==3.19.2
     # via sailthru-client
 six==1.16.0
     # via
     #   edx-ace
     #   python-dateutil
+soupsieve==2.5
+    # via beautifulsoup4
 sqlparse==0.4.4
     # via django
 stevedore==5.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,13 +25,16 @@ attrs==23.1.0
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/quality.txt
+    #   backports-zoneinfo
     #   celery
     #   kombu
+beautifulsoup4==4.12.2
+    # via -r requirements/quality.txt
 billiard==4.1.0
     # via
     #   -r requirements/quality.txt
     #   celery
-black==23.9.1
+black==23.10.0
     # via -r requirements/dev.in
 build==1.0.3
     # via
@@ -90,8 +93,9 @@ code-annotations==1.5.0
 coverage[toml]==7.3.2
     # via
     #   -r requirements/quality.txt
+    #   coverage
     #   pytest-cov
-diff-cover==7.7.0
+diff-cover==8.0.0
     # via -r requirements/dev.in
 dill==0.3.7
     # via
@@ -134,13 +138,14 @@ edx-ace==1.7.0
     # via -r requirements/quality.txt
 edx-django-utils==5.7.0
     # via -r requirements/quality.txt
-edx-i18n-tools==1.2.0
+edx-i18n-tools==1.3.0
     # via -r requirements/dev.in
 edx-lint==5.3.4
     # via -r requirements/quality.txt
 edx-opaque-keys[django]==2.5.1
     # via
     #   -r requirements/quality.txt
+    #   edx-opaque-keys
     #   openedx-events
 exceptiongroup==1.1.3
     # via
@@ -184,6 +189,8 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/quality.txt
     #   astroid
+lxml==4.9.3
+    # via edx-i18n-tools
 markupsafe==2.1.3
     # via
     #   -r requirements/quality.txt
@@ -198,7 +205,7 @@ newrelic==9.1.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-openedx-events==8.9.0
+openedx-events==9.0.0
     # via -r requirements/quality.txt
 openedx-filters==1.6.0
     # via -r requirements/quality.txt
@@ -241,7 +248,7 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/quality.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -249,7 +256,7 @@ py==1.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via -r requirements/quality.txt
 pycparser==2.21
     # via
@@ -327,7 +334,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/quality.txt
     #   edx-ace
-simplejson==3.19.1
+simplejson==3.19.2
     # via
     #   -r requirements/quality.txt
     #   sailthru-client
@@ -343,6 +350,10 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
+soupsieve==2.5
+    # via
+    #   -r requirements/quality.txt
+    #   beautifulsoup4
 sqlparse==0.4.4
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -28,10 +28,13 @@ babel==2.13.0
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/test.txt
+    #   backports-zoneinfo
     #   celery
     #   kombu
 beautifulsoup4==4.12.2
-    # via pydata-sphinx-theme
+    # via
+    #   -r requirements/test.txt
+    #   pydata-sphinx-theme
 billiard==4.1.0
     # via
     #   -r requirements/test.txt
@@ -79,6 +82,7 @@ code-annotations==1.5.0
 coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pytest-cov
 cryptography==41.0.4
     # via secretstorage
@@ -126,6 +130,7 @@ edx-django-utils==5.7.0
 edx-opaque-keys[django]==2.5.1
     # via
     #   -r requirements/test.txt
+    #   edx-opaque-keys
     #   openedx-events
 exceptiongroup==1.1.3
     # via
@@ -186,7 +191,7 @@ newrelic==9.1.0
     #   edx-django-utils
 nh3==0.2.14
     # via readme-renderer
-openedx-events==8.9.0
+openedx-events==9.0.0
     # via -r requirements/test.txt
 openedx-filters==1.6.0
     # via -r requirements/test.txt
@@ -211,7 +216,7 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -290,7 +295,7 @@ sailthru-client==2.2.3
     #   edx-ace
 secretstorage==3.3.3
     # via keyring
-simplejson==3.19.1
+simplejson==3.19.2
     # via
     #   -r requirements/test.txt
     #   sailthru-client
@@ -302,7 +307,9 @@ six==1.16.0
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
-    # via beautifulsoup4
+    # via
+    #   -r requirements/test.txt
+    #   beautifulsoup4
 sphinx==6.2.1
     # via
     #   -r requirements/doc.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.41.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.2.1
+pip==23.3
     # via -r requirements/pip.in
 setuptools==68.2.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -24,8 +24,11 @@ attrs==23.1.0
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/test.txt
+    #   backports-zoneinfo
     #   celery
     #   kombu
+beautifulsoup4==4.12.2
+    # via -r requirements/test.txt
 billiard==4.1.0
     # via
     #   -r requirements/test.txt
@@ -76,6 +79,7 @@ code-annotations==1.5.0
 coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pytest-cov
 dill==0.3.7
     # via pylint
@@ -116,6 +120,7 @@ edx-lint==5.3.4
 edx-opaque-keys[django]==2.5.1
     # via
     #   -r requirements/test.txt
+    #   edx-opaque-keys
     #   openedx-events
 exceptiongroup==1.1.3
     # via
@@ -157,7 +162,7 @@ newrelic==9.1.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==8.9.0
+openedx-events==9.0.0
     # via -r requirements/test.txt
 openedx-filters==1.6.0
     # via -r requirements/test.txt
@@ -179,11 +184,11 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via -r requirements/quality.in
 pycparser==2.21
     # via
@@ -248,7 +253,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/test.txt
     #   edx-ace
-simplejson==3.19.1
+simplejson==3.19.2
     # via
     #   -r requirements/test.txt
     #   sailthru-client
@@ -260,6 +265,10 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle
+soupsieve==2.5
+    # via
+    #   -r requirements/test.txt
+    #   beautifulsoup4
 sqlparse==0.4.4
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,8 +20,11 @@ attrs==23.1.0
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/base.txt
+    #   backports-zoneinfo
     #   celery
     #   kombu
+beautifulsoup4==4.12.2
+    # via -r requirements/base.txt
 billiard==4.1.0
     # via
     #   -r requirements/base.txt
@@ -64,7 +67,9 @@ click-repl==0.3.0
 code-annotations==1.5.0
     # via -r requirements/test.in
 coverage[toml]==7.3.2
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -99,6 +104,7 @@ edx-django-utils==5.7.0
 edx-opaque-keys[django]==2.5.1
     # via
     #   -r requirements/base.txt
+    #   edx-opaque-keys
     #   openedx-events
 exceptiongroup==1.1.3
     # via pytest
@@ -124,7 +130,7 @@ newrelic==9.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==8.9.0
+openedx-events==9.0.0
     # via -r requirements/base.txt
 openedx-filters==1.6.0
     # via -r requirements/base.txt
@@ -140,7 +146,7 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/base.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -186,7 +192,7 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/base.txt
     #   edx-ace
-simplejson==3.19.1
+simplejson==3.19.2
     # via
     #   -r requirements/base.txt
     #   sailthru-client
@@ -195,6 +201,10 @@ six==1.16.0
     #   -r requirements/base.txt
     #   edx-ace
     #   python-dateutil
+soupsieve==2.5
+    # via
+    #   -r requirements/base.txt
+    #   beautifulsoup4
 sqlparse==0.4.4
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
### Description
This PR adds templates for individual and digest emails for forum notification

### How to Test

#### Individual
1. Install this branch in your environment
2. Create a new post, a new response, and a new comment
3. The content of the emails should be stored in the `/tmp/openedx/emails` folder in the LMS container.

#### Digest
1. Login as an instructor
2. Setup the email digest feature as daily
3. Login as a student
5. Interact with the forum (comment, answer, or new thread)
6. Run the following command to trigger the email notification for the digest: `tutor dev exec lms ./manage.py lms forum_digest --digest daily`
7. The content of the digest email should be stored in the /tmp/openedx/emails folder in the LMS container.