### PR TITLE
feat: add documentation in instructor dashboard

### DIFF
--- a/platform_plugin_forum_email_notifier/static/html/forum_notifier.html
+++ b/platform_plugin_forum_email_notifier/static/html/forum_notifier.html
@@ -1,15 +1,35 @@
 {% load i18n %}
 
 <div class="email-notifier-instructor-wrapper">
-    {% trans "Forum email notifications preferences" %}
+    <div>
+        <p class="title-list">{% trans "In this section you can set your email notification preferences for the discussion forum. The available options are:" %}</p>
+        <ul class="list-container">
+            <li>{% trans "None: I don't want to receive any email notifications." %}</li>
+            <li>{% trans "All posts: I want to receive email notifications for all posts." %}</li>
+            <li>
+                {% trans "Only posts I'm following: I want to receive email notifications for posts I'm following." %}
+            </li>
+            <li>
+                {% trans "All posts (Daily digest): I want to receive email notifications for all posts in a daily digest." %}
+            </li>
+            <li>
+                {% trans "All posts (Weekly digest): I want to receive email notifications for all posts in a weekly digest." %}
+            </li>
+        </ul>
+    </div>
 
-    <select class="email-notifications-select">
+    <p><b>{% trans "These notifications are only sent to the instructor of the course." %}</b></p>
+    <p>{% trans "The available notifications of the discussion forum are: created post, response to post, comment to post. These notifications are sent to the email address associated with your account. Below you can select the type of notifications you want to receive:" %}</p>
+
+    <select class="dropdown email-notifications-select">
         {% for value, text in options %}
-        {% if value == current_preference  %}
-        <option class="email-notifications-options" value={{value}} selected>{{ text }}</option>
-        {% else %}
-        <option class="email-notifications-options" value={{value}}>{{ text }}</option>
-        {% endif %}
+            {% if value == current_preference %}
+                <option class="email-notifications-options" value="{{value}}" selected>{{ text }}</option>
+            {% else %}
+                <option class="email-notifications-options" value="{{value}}">{{ text }}</option>
+            {% endif %}
         {% endfor %}
     </select>
 </div>
+
+<script type="text/javascript" src="/platform_plugin_forum_email_notifier/static/js/src/forum_notifier.js"></script>

--- a/platform_plugin_forum_email_notifier/static/js/forum_notifier.js
+++ b/platform_plugin_forum_email_notifier/static/js/forum_notifier.js
@@ -1,33 +1,45 @@
 function getCookie(name) {
   let cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-      const cookies = document.cookie.split(';');
-      for (let i = 0; i < cookies.length; i++) {
-          const cookie = cookies[i].trim();
-          // Does this cookie string begin with the name we want?
-          if (cookie.substring(0, name.length + 1) === (name + '=')) {
-              cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-              break;
-          }
+  if (document.cookie && document.cookie !== "") {
+    const cookies = document.cookie.split(";");
+    for (let i = 0; i < cookies.length; i++) {
+      const cookie = cookies[i].trim();
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) === name + "=") {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
       }
+    }
   }
   return cookieValue;
 }
 
-
-$('.email-notifications-select').on('change', function(select) {
-  fetch('instructor/api/forum_email_notification_preference', {
-    method: 'PUT',
+$(".email-notifications-select").on("change", function (select) {
+  fetch("instructor/api/forum_email_notification_preference", {
+    method: "PUT",
     body: JSON.stringify({
-      'preference': parseInt($(this).val())
+      preference: parseInt($(this).val()),
     }),
     headers: {
-      'Content-Type': 'application/json',
-      'X-CSRFToken': getCookie('csrftoken')
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCookie("csrftoken"),
     },
-    }).then(function(response) {
+  })
+    .then(function (response) {
       return response.json();
-    }).then(function(data) {
+    })
+    .then(function (data) {
       console.log(data);
     });
+});
+
+$(function () {
+  const cssUrl = "https://cdn.jsdelivr.net/npm/@edx/paragon@20.45.5/dist/paragon.min.css";
+
+  $("<link>")
+    .attr({
+      href: cssUrl,
+      rel: "stylesheet",
+    })
+    .appendTo("head");
 });


### PR DESCRIPTION
### Description
This PR adds the documentation to the instructor dashboard.

### How to Test
1. Install this branch in your environment
2. Go to the instructor dashboard
3. Select the forum notifications tab
4. You should see the added documentation

### Screenshot
![image](https://github.com/eduNEXT/platform-plugin-forum-email-notifier/assets/64033729/e3a77a5e-efe3-4ab8-bd97-e02955466b5d)
